### PR TITLE
Remove reference to gutenberg_, swap with wp_

### DIFF
--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -85,7 +85,7 @@ function block_core_calendar_has_published_posts() {
 	}
 
 	// On single sites we try our own cached option first.
-	$has_published_posts = get_option( 'gutenberg_calendar_block_has_published_posts', null );
+	$has_published_posts = get_option( 'wp_calendar_block_has_published_posts', null );
 	if ( null !== $has_published_posts ) {
 		return (bool) $has_published_posts;
 	}
@@ -103,7 +103,7 @@ function block_core_calendar_has_published_posts() {
 function block_core_calendar_update_has_published_posts() {
 	global $wpdb;
 	$has_published_posts = (bool) $wpdb->get_var( "SELECT 1 as test FROM {$wpdb->posts} WHERE post_type = 'post' AND post_status = 'publish' LIMIT 1" );
-	update_option( 'gutenberg_calendar_block_has_published_posts', $has_published_posts );
+	update_option( 'wp_calendar_block_has_published_posts', $has_published_posts );
 	return $has_published_posts;
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
https://core.trac.wordpress.org/ticket/54446
In https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/blocks/calendar.php on line 103 (in the function block_core_calendar_update_has_published_posts) the option is named gutenberg_calendar_block_has_published_posts. Should it be called something else? The option is retrieved in the function block_core_calendar_has_published_posts some lines above, and may be updated as well.

Should be backported to WordPress 5.9.

<!-- Please describe what you have changed or added -->
Swapped gutenberg_* with wp_* in the option name.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
